### PR TITLE
Single type

### DIFF
--- a/wb-es/src/wb_es/bulk/core.clj
+++ b/wb-es/src/wb_es/bulk/core.clj
@@ -20,9 +20,9 @@
                (if-not (= (name action-name) "delete")
                  (format "%s\n%s"
                          (json/generate-string {action-name (if index
-                                                              (assoc (.metadata doc) :_index index) ; ie to specify test index
-                                                              (.metadata doc))})
-                         (json/generate-string (.data doc))))))
+                                                              (assoc (meta doc) :_index index) ; ie to specify test index
+                                                              (meta doc))})
+                         (json/generate-string doc)))))
         (clojure.string/join "\n")
         (format "%s\n")))) ;trailing \n is necessary for Elasticsearch to parse the request
 

--- a/wb-es/src/wb_es/datomic/data/core.clj
+++ b/wb-es/src/wb_es/datomic/data/core.clj
@@ -91,4 +91,11 @@
           :variation/id variation/->Variation
           :wbprocess/id wbprocess/->Wbprocess
           (throw (Exception. "Not sure how to handle the data type. Throw an error to let you know")))]
-    (constructor-function entity)))
+    (let [document (constructor-function entity)
+          doc-data (.data document)
+          doc-meta (.metadata document)
+          page-type (clojure.string/replace (data-util/get-type-name entity) #"-" "_")]
+      (-> (merge {:page_type page-type}
+                 doc-data)
+          (with-meta doc-meta))
+      )))

--- a/wb-es/src/wb_es/datomic/data/do_term.clj
+++ b/wb-es/src/wb_es/datomic/data/do_term.clj
@@ -7,9 +7,10 @@
 
 (deftype Do-term [entity]
   data-util/Document
-  (metadata [this] (assoc (data-util/default-metadata entity) :_type "disease"))
+  (metadata [this] (data-util/default-metadata entity))
   (data [this]
-    {:wbid (:do-term/id entity)
+    {:page_type "disease"
+     :wbid (:do-term/id entity)
      :label (:do-term/name entity)
      :other_names (->> (:do-term/synonym entity)
                        (keep (fn [holder]

--- a/wb-es/src/wb_es/datomic/data/pcr_product.clj
+++ b/wb-es/src/wb_es/datomic/data/pcr_product.clj
@@ -6,7 +6,8 @@
 
 (deftype Pcr-product [entity]
   data-util/Document
-  (metadata [this] (assoc (data-util/default-metadata entity) :_type "pcr-oligo"))
+  (metadata [this] (data-util/default-metadata entity))
   (data [this]
-    {:wbid (:pcr-product/id entity)
+    {:page_type "pcr_oligo"
+     :wbid (:pcr-product/id entity)
      :label (:pcr-product/id entity)}))

--- a/wb-es/src/wb_es/datomic/data/util.clj
+++ b/wb-es/src/wb_es/datomic/data/util.clj
@@ -22,11 +22,10 @@
 (defn default-metadata
   "default implementation of the data method of Document protocol"
   [entity]
-  (let [ident (get-ident-attr entity)
-        type (get-type-name entity)]
+  (let [ident (get-ident-attr entity)]
     (if ident
       {:_index release-id
-       :_type type
+       :_type "generic"
        :_id (format "%s:%s" type (ident entity))}
       (throw (Exception. "cannot identify ident attribute of the entity")))))
 

--- a/wb-es/src/wb_es/mappings/core.clj
+++ b/wb-es/src/wb_es/mappings/core.clj
@@ -34,6 +34,8 @@
     :other_names {:type "string"
                   :include_in_all false
                   :analyzer "keyword_ignore_case"}
+    :page_type {:type "string"
+                :analyzer "keyword_ignore_case"}
     :paper_type {:type "string"
                  :analyzer "keyword_ignore_case"}
     :species {:properties

--- a/wb-es/src/wb_es/mappings/core.clj
+++ b/wb-es/src/wb_es/mappings/core.clj
@@ -7,7 +7,7 @@
                 :label {:type "string"}
                 :ref_type {:type "string"}}})
 
-(def default-mapping
+(def generic-mapping
   {:properties
    {:wbid {:type "string"
            :analyzer "keyword"
@@ -66,4 +66,4 @@
                           "keyword_ignore_case" {:type "custom"
                                                  :tokenizer "keyword"
                                                  :filter ["lowercase"]}}}}
-   :mappings {:_default_ default-mapping}})
+   :mappings {:generic generic-mapping}})

--- a/wb-es/src/wb_es/web/core.clj
+++ b/wb-es/src/wb_es/web/core.clj
@@ -10,7 +10,7 @@
 (defn get-filter [options]
   (->> []
        (cons (when-let [type-value (:type options)]
-               {:type {:value (clojure.string/replace type-value #"_" "-")}}))
+               {:term {:page_type type-value}}))
        (cons (when-let [species-value (some->> (:species options)
                                                (clojure.string/lower-case))]
                {:term {:species.key species-value}}))

--- a/wb-es/src/wb_es/web/integration.clj
+++ b/wb-es/src/wb_es/web/integration.clj
@@ -3,7 +3,7 @@
 (defn- pack-search-obj [doc]
   (let [doc-source (:_source doc)]
     {:id (:wbid doc-source)
-     :class (clojure.string/replace (:_type doc) "-" "_")
+     :class (clojure.string/replace (get-in doc [:_source :page_type]) "-" "_")
      :label (or (:label doc-source)
                 (:wbid doc-source))
      :taxonomy (get-in doc-source [:species :key])}))

--- a/wb-es/test/wb_es/core_test.clj
+++ b/wb-es/test/wb_es/core_test.clj
@@ -93,7 +93,7 @@
                                :hits
                                (first))]
             (is (= "W02C12" (get-in first-hit [:_source :wbid])))
-            (is (= "clone" (get-in first-hit [:_type])))))
+            (is (= "clone" (get-in first-hit [:_source :page_type])))))
         (testing "autocomplete by clone WBID"
           (let [hits (->> (autocomplete "W02C")
                           :hits

--- a/wb-es/test/wb_es/core_test.clj
+++ b/wb-es/test/wb_es/core_test.clj
@@ -149,7 +149,13 @@
           (is (some (fn [hit]
                       (= "Parkinson's disease"
                          (get-in hit [:_source :label])))
-                    hits)))))
+                    hits))))
+
+      (testing "search with page_type do_term"
+        (apply index-datomic-entity disease-parks)
+        (let [hits (search nil {:type "disease"})]
+          (is (= "disease"
+                 (get-in hits [:hits :hits 0 :_source :page_type]))))))
     ))
 
 (deftest go-term-type-test

--- a/wb-es/test/wb_es/core_test.clj
+++ b/wb-es/test/wb_es/core_test.clj
@@ -230,3 +230,13 @@
                            (get-in hit [:_source :label])))
                       hits)))))
       )))
+
+(deftest pcr-product-type-test
+  (testing "pcr-product is searchable by page_type pcr_oligo"
+    (let [db (d/db datomic-conn)]
+      (do
+        (index-datomic-entity (d/entity db [:pcr-product/id "sjj_ZK822.2"]))
+        (let [hit (-> (search "sjj_ZK822.2" {:type "pcr_oligo"})
+                      (get-in [:hits :hits 0 :_source]))]
+          (= "sjj_ZK822.2" (:wbid hit))
+          (= "pcr_oligo" (:page_type hit)))))))


### PR DESCRIPTION
- use only a single (elasticsearch) type, called "generic"
- add field page_type to mapping
- query page_type field when "type" parameter is set
- refactor create-document
